### PR TITLE
Add a custom column type

### DIFF
--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -46,6 +46,7 @@ impl SqlGenerator for Pg {
             Boolean => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type( t )),
             Binary => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type( t )),
             Foreign(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type( t )),
+            Custom(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type( t )),
             Array(it) => format!("{}\"{}\" {}",Pg::prefix(ex),name,Pg::print_type( Array(box *it) )),
         };
 
@@ -95,6 +96,7 @@ impl Pg {
             Double => format!("DOUBLE"),
             Boolean => format!("BOOLEAN"),
             Binary => format!("BINARY"),
+            Custom(t) => format!("{}", t),
             Foreign(t) => format!("INTEGER REFERENCES {}", t),
             Array(meh) => format!("{}[]", Pg::print_type(*meh)),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,10 @@ pub enum Type {
     /// Provide the name of a table to point to
     Foreign(&'static str),
 
+    /// Used for types not Implemented by the migration system.
+    /// This field is not statically checked.
+    Custom(&'static str),
+
     // FIXME: Figure out a way to do this nicely
     // Foreign(&'static str, &'static str),
     /// Any type can also exist as an array type

--- a/src/tests/pg/add_column.rs
+++ b/src/tests/pg/add_column.rs
@@ -54,6 +54,12 @@ fn foreign() {
 }
 
 #[test]
+fn custom() {
+    let sql = Pg::add_column(true, "Point", &Column::new(Custom("POINT")));
+    assert_eq!(String::from("ADD COLUMN \"Point\" POINT"), sql);
+}
+
+#[test]
 fn array_text() {
     let sql = Pg::add_column(true, "Array of Text", &Column::new(Array(box Text)));
     assert_eq!(String::from("ADD COLUMN \"Array of Text\" TEXT[]"), sql);
@@ -93,6 +99,12 @@ fn array_boolean() {
 fn array_binary() {
     let sql = Pg::add_column(true, "Array of Binary", &Column::new(Array(box Binary)));
     assert_eq!(String::from("ADD COLUMN \"Array of Binary\" BINARY[]"), sql);
+}
+
+#[test]
+fn array_custom() {
+    let sql = Pg::add_column(true, "Array of Point", &Column::new(Array(box Custom("POINT"))));
+    assert_eq!(String::from("ADD COLUMN \"Array of Point\" POINT[]"), sql);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #13

Allow to define a custom column type not explicitly declared on the migration system with the `add_column()` command.

This limits the static checker security, but also allows much more flexibility using extensions and custom backend types.