### PR TITLE
update diesel integration documentation

### DIFF
--- a/guides/diesel-setup.md
+++ b/guides/diesel-setup.md
@@ -8,25 +8,24 @@
 
 ---
 
-Using rust migrations (via `barrel`) with `diesel` is really simple. First, you need to add the `barrel-migrations` to the features list for your `diesel` dependency. Note that currently `barrel` only supports postgres databases.
-
-
-```toml
-[dependencies]
-diesel = { version = "1.2", features = ["barrel-migrations", "postgres"] }
-# ...
-```
-
-Also make sure that you installed the `diesel_cli` with the `barrel-migrations` feature flag as well
+Using rust migrations (via `barrel`) with `diesel` is really simple. First make sure that you installed the `diesel_cli` with the `barrel-migrations` feature flag:
 
 ```bash
 ~ cargo install diesel_cli --features="barrel-migrations"
 ```
 
-From this point using `diesel` is very similar to how you normally use it. The only difference is that you should provide a `--type` flag when letting diesel generate a migration for you. Running migrations doesn't change.
+Note that currently `barrel` only supports postgres databases.
+
+```toml
+[dependencies]
+diesel = { version = "1.3", features = ["postgres"] }
+# ...
+```
+
+From this point using `diesel` is very similar to how you normally use it. The only difference is that you should provide a `--format` flag when letting diesel generate a migration for you. Running migrations doesn't change.
 
 ```bash
-~ diesel migration generate <name> --type="barrel"
+~ diesel migration generate <name> --format="barrel"
 ~ diesel migration run
 ```
 


### PR DESCRIPTION
The `diesel` dependency never had a `barrel-migrations`-feature, only `diesel_cli` have one.
The command line for barrel migrations changed (`--format` instead of `--type`).
I also bumped the diesel version.