### PR TITLE
fixes BINARY column type in psql

### DIFF
--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -93,7 +93,7 @@ impl Pg {
             Float => format!("FLOAT"),
             Double => format!("DOUBLE"),
             Boolean => format!("BOOLEAN"),
-            Binary => format!("BINARY"),
+            Binary => format!("BYTEA"),
             Custom(t) => format!("{}", t),
             Foreign(t) => format!("INTEGER REFERENCES {}", t),
             Array(meh) => format!("{}[]", Pg::print_type(*meh)),

--- a/src/tests/pg/add_column.rs
+++ b/src/tests/pg/add_column.rs
@@ -44,7 +44,7 @@ fn boolean() {
 #[test]
 fn binary() {
     let sql = Pg::add_column(true, "Binary", &Column::new(Binary));
-    assert_eq!(String::from("ADD COLUMN \"Binary\" BINARY"), sql);
+    assert_eq!(String::from("ADD COLUMN \"Binary\" BYTEA"), sql);
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn array_binary() {
         "Array of Binary",
         &Column::new(Array(Box::new(Binary))),
     );
-    assert_eq!(String::from("ADD COLUMN \"Array of Binary\" BINARY[]"), sql);
+    assert_eq!(String::from("ADD COLUMN \"Array of Binary\" BYTEA[]"), sql);
 }
 
 #[test]


### PR DESCRIPTION
The SQL standard doesn't define a `BINARY` type and postgres uses `BYTEA` for binary data.
https://www.postgresql.org/docs/9.0/static/datatype-binary.html