### PR TITLE
Pg: Postgres `drop_table_if_exists` generates the wrong statement

### DIFF
--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -22,7 +22,7 @@ impl SqlGenerator for Pg {
     }
 
     fn drop_table_if_exists(name: &str) -> String {
-        format!("DROP TABLE IF EXISTS \"{}\", name)
+        format!("DROP TABLE IF EXISTS \"{}\"", name)
     }
 
     fn rename_table(old: &str, new: &str) -> String {

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -22,7 +22,7 @@ impl SqlGenerator for Pg {
     }
 
     fn drop_table_if_exists(name: &str) -> String {
-        format!("DROP TABLE \"{}\" IF EXISTS", name)
+        format!("DROP TABLE IF EXISTS \"{}\", name)
     }
 
     fn rename_table(old: &str, new: &str) -> String {

--- a/src/tests/pg/create_table.rs
+++ b/src/tests/pg/create_table.rs
@@ -104,7 +104,7 @@ fn drop_table_if_exists() {
 
     assert_eq!(
         m.make::<Pg>(),
-        String::from("DROP TABLE \"users\" IF EXISTS;")
+        String::from("DROP TABLE IF EXISTS \"users\";")
     );
 }
 

--- a/src/tests/pg/simple.rs
+++ b/src/tests/pg/simple.rs
@@ -27,7 +27,7 @@ fn drop_table() {
 #[test]
 fn drop_table_if_exists() {
     let sql = Pg::drop_table_if_exists("table_to_drop");
-    assert_eq!(String::from("DROP TABLE \"table_to_drop\" IF EXISTS"), sql);
+    assert_eq!(String::from("DROP TABLE IF EXISTS \"table_to_drop\""), sql);
 }
 
 #[test]


### PR DESCRIPTION
When I use the `Pg::drop_table_if_exists` it generates the following statement:  `DROP TABLE "Scoring" IF EXISTS;`  which causes the following error: `syntax error at or near \"IF\"`.

I double-checked the [Postgres docs table docs](https://www.postgresql.org/docs/11/sql-droptable.html)  

This PR changes the output to be `DROP  TABLE IF EXISTS "Scoring";`