### PR TITLE
Add support for altering a table

### DIFF
--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -26,11 +26,11 @@ impl SqlGenerator for MySql {
     }
 
     fn rename_table(old: &str, new: &str) -> String {
-        format!("RENAME TABLE \"{}\" TO \"{}\"", old, new)
+        format!("RENAME TABLE `{}` TO `{}`", old, new)
     }
 
     fn alter_table(name: &str) -> String {
-        format!("ALTER TABLE \"{}\"", name)
+        format!("ALTER TABLE `{}`", name)
     }
 
     fn add_column(ex: bool, name: &str, tt: &Type) -> String {

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -77,6 +77,20 @@ impl Migration {
                 &mut DropTable(ref name) => s.push_str(&T::drop_table(name)),
                 &mut DropTableIfExists(ref name) => s.push_str(&T::drop_table_if_exists(name)),
                 &mut RenameTable(ref old, ref new) => s.push_str(&T::rename_table(old, new)),
+                &mut ChangeTable(ref mut t, ref mut cb) => {
+                    cb(t);
+                    let vec = t.make::<T>(true);
+                    s.push_str(&T::alter_table(&t.meta.name()));
+                    s.push_str(" ");
+                    let l = vec.len();
+                    for (i, slice) in vec.iter().enumerate() {
+                        s.push_str(slice);
+
+                        if i < l - 1 {
+                            s.push_str(", ");
+                        }
+                    }
+                }
                 _ => {}
             }
 

--- a/src/tests/mysql/simple.rs
+++ b/src/tests/mysql/simple.rs
@@ -35,7 +35,7 @@ fn drop_table_if_exists() {
 fn rename_table() {
     let sql = MySql::rename_table("old_table", "new_table");
     assert_eq!(
-        String::from("RENAME TABLE \"old_table\" TO \"new_table\""),
+        String::from("RENAME TABLE `old_table` TO `new_table`"),
         sql
     );
 }
@@ -43,5 +43,5 @@ fn rename_table() {
 #[test]
 fn alter_table() {
     let sql = MySql::alter_table("table_to_alter");
-    assert_eq!(String::from("ALTER TABLE \"table_to_alter\""), sql);
+    assert_eq!(String::from("ALTER TABLE `table_to_alter`"), sql);
 }


### PR DESCRIPTION
Looks like the Migration generator was lacking support for changing a table. I've added the basic code to handle that.