### PR TITLE
Improving documentation for 0.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,39 +9,48 @@
 
 A powerful schema migration builder, that let's you write your SQL migrations in Rust.
 
-`barrel` makes writing migrations for different databases as easy as possible. It provides you with a common API over SQL, with certain features only provided for database specific implementations.
+`barrel` makes writing migrations for different databases as easy as possible.
+It provides you with a common API over SQL,
+with certain features only provided for database specific implementations.
 This way you can focus on your Rust code, and stop worrying about SQL.
-
-While `barrel` works on stable rust with most features, please note that some experimental features might require the nightly compiler.
 
 ## Example
 
 The following example will help you get started
 
 ```rust
-extern crate barrel;
-
-use barrel::*;
+use barrel::{types, Migration, Pg};
 use barrel::backend::Pg;
 
 fn main() {
     let mut m = Migration::new();
+    
     m.create_table("users", |t| {
-        t.add_column("name", Type::Text);
-        t.add_column("age", Type::Integer);
-        t.add_column("owns_plushy_sharks", Type::Boolean);
+        t.add_column("name", types::varchar(255));
+        t.add_column("age", types::integer());
+        t.add_column("owns_plushy_sharks", types::boolean());
     });
-
+    
     println!("{}", m.make::<Pg>());
 }
 ```
-
-If you have feedback [regarding the API](https://github.com/spacekookie/barrel/issues/1) or things you would want barrel to do, please open an issue. And documentation PR's are always welcome 💚
 
 ## Using Diesel
 
 Since `diesel 1.2.0` it's possible to now use `barrel` for migrations with `diesel`. A guide with some more information on how to get started can be found [here](https://github.com/spacekookie/barrel/blob/master/guides/diesel-setup.md)
 
+### Migration guide
+
+If you've been using `barrel` to write migrations for `diesel` before the `0.5.0` release,
+some migration of your migrations will be required.
+Since `0.5.0` the way types are constructed changed.
+Instead of constructing a type with `Types::VarChar(255)` (an enum variant),
+the types are now provided by a module called `types` and builder functions.
+The same type would now be `types::varchar(255)` (a function call),
+which then returns a `Type` enum.
+
+You can also directly created your own `Type` builders this way.
+Check the docs for details!
 
 ## Unstable features
 
@@ -49,11 +58,17 @@ Starting with `v0.2.4` `barrel` now has an `unstable` feature flag which will hi
 
 ## License
 
-`barrel` is free software: you can redistribute it and/or modify it under the terms of the MIT Public License.
+`barrel` is free software: you can redistribute it and/or modify it
+under the terms of the MIT Public License.
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the MIT Public License for more details.
-
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the MIT Public License for more details.
 
 ## Conduct
 
-In the interest of fostering an open and welcoming environment, the `barrel` project pledges to making participation a harassment-free experience for everyone. See [Code of Conduct](code_of_conduct.md) for details. In case of violations, e-mail [kookie@spacekookie.de](mailto:kookie@spacekookie.de).
+In the interest of fostering an open and welcoming environment,
+the `barrel` project pledges to making participation a harassment-free experience for everyone.
+See [Code of Conduct](code_of_conduct.md) for details.
+In case of violations, e-mail [kookie@spacekookie.de](mailto:kookie@spacekookie.de).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@
 //! The following code is a simple example of how to get going with `barrel`
 //!
 //! ```rust
-//! extern crate barrel;
-//!
 //! use barrel::{types, Migration};
 //!
 //! fn main() {
@@ -50,7 +48,10 @@
 //! migration yourself simply run `Migration::exec()` where you provide a
 //! generic `SqlGenerator` type according to your database backend
 //!
-//! ```rust,ignore
+//! ```rust
+//! # use barrel::backend::Pg;
+//! # use barrel::Migration;
+//! # let mut m = Migration::new();
 //! // Example for pgsql
 //! m.make::<Pg>();
 //! ```
@@ -60,20 +61,30 @@
 //! `DatabaseExecutor` trait for a type of yours that knows how to execute SQL.
 //! Running a migration with `barrel` is then super easy.
 //!
-//! ```rust,ignore
-//! m.execute(executor);
+//! ```rust
+//! use barrel::connectors::DatabaseExecutor;
+//! # use barrel::Migration;
+//! # use barrel::backend::Pg;
+//!
+//! struct MyExecutor;
+//! impl DatabaseExecutor for MyExecutor {
+//!     fn execute<S: Into<String>>(&mut self, sql: S) {
+//!         # let s: String = sql.into();
+//!         // ...
+//!     }
+//! }
+//!
+//! # let mut m = Migration::new();
+//! # let mut executor = MyExecutor;
+//! m.execute::<MyExecutor, Pg>(&mut executor);
 //! ```
 //!
 //! In this case `executor` is your provided type which implements the required
 //! trait. You can read more about this in the [connectors](connectors/index.html)
 //! module docs.
 //!
-//! **Important**: This crate is still early in development and the API might
-//! change rapidely between pre-release versions. I will try as best I can to
-//! include changes in the `CHANGELOG` but can not guarantee perfect coverage.
-//!
-//! Also, if there is missing or invalid documentation for this crate, PR's are
-//! always welcome 💚
+//! If you find database-specific features or documentation lacking,
+//! don't hesitate to open an issue/PR about it.
 
 #[cfg(not(any(feature = "sqlite3", feature = "pg", feature = "mysql" )))]
 compile_error!("`barrel` cannot be built without a database backend speccified via cargo `--features`");


### PR DESCRIPTION
This PR is a bunch of small changes to make the docs better.
For one, it finally updates the `README.md` to the new API
that's coming in 0.5.0 (removing yet another blocker for
that release!)

Additionally I finally fixed the doc tests in the crate docs.
They were always set to `ignore` which irked me.
Now they just don't show some behind-the-scenes code that's
required to make it all work.

Incidentally, while writing the doc tests for `Migration::execute`
I noticed that the usability there really could be improved.