### PR TITLE
changed match arm to match create_table_if_not_exists

### DIFF
--- a/src/migration.rs
+++ b/src/migration.rs
@@ -143,7 +143,7 @@ impl Migration {
         ));
 
         return match self.changes.last_mut().unwrap() {
-            &mut DatabaseChange::CreateTable(ref mut t, _) => &mut t.meta,
+            &mut DatabaseChange::CreateTableIfNotExists(ref mut t, _) => &mut t.meta,
             _ => unreachable!(),
         };
     }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -73,7 +73,27 @@ impl Migration {
                         }
                     }
                     s.push_str(")");
-                }
+                },
+                &mut CreateTableIfNotExists(ref mut t, ref mut cb) => {
+                    if t.meta.has_id {
+                        t.add_column("id", types::primary());
+                    }
+
+                    cb(t); // Run the user code
+                    let vec = t.make::<T>(false);
+                    s.push_str(&T::create_table_if_not_exists(&t.meta.name()));
+                    s.push_str(" (");
+                    let l = vec.len();
+                    for (i, slice) in vec.iter().enumerate() {
+                        s.push_str(slice);
+
+                        if i < l - 1 {
+                            s.push_str(", ");
+                        }
+                    }
+                    s.push_str(")");
+                },
+
                 &mut DropTable(ref name) => s.push_str(&T::drop_table(name)),
                 &mut DropTableIfExists(ref name) => s.push_str(&T::drop_table_if_exists(name)),
                 &mut RenameTable(ref old, ref new) => s.push_str(&T::rename_table(old, new)),

--- a/src/table.rs
+++ b/src/table.rs
@@ -75,6 +75,7 @@ impl Table {
         let mut s = Vec::new();
 
         for change in &mut self.changes {
+            println!("in make's change loop change: {:?}", change.clone());
             s.push(match change {
                 &mut AddColumn(ref name, ref col) => {
                     let mut s = T::add_column(ex, name, &col);

--- a/src/table.rs
+++ b/src/table.rs
@@ -75,7 +75,6 @@ impl Table {
         let mut s = Vec::new();
 
         for change in &mut self.changes {
-            println!("in make's change loop change: {:?}", change.clone());
             s.push(match change {
                 &mut AddColumn(ref name, ref col) => {
                     let mut s = T::add_column(ex, name, &col);

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -15,6 +15,14 @@ fn create_multiple_tables() {
 }
 
 #[test]
+fn create_table_if_not_exists() {
+    let mut migr = Migration::new();
+    migr.create_table_if_not_exists("foo", |_| {});
+
+    assert!(migr.changes.len() == 1);
+}
+
+#[test]
 fn pin_public_api() {
     // The best sql type because it's very queer 🏳️‍🌈
     let tt = Type::new(BaseType::Custom("GAY"));

--- a/src/tests/mysql/create_table.rs
+++ b/src/tests/mysql/create_table.rs
@@ -20,3 +20,15 @@ fn create_multiple_tables() {
     });
     assert_eq!(m.make::<MySql>(), String::from("CREATE TABLE artist (id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, name TEXT, description TEXT, pic TEXT, mbid TEXT);CREATE TABLE album (id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, name TEXT, pic TEXT, mbid TEXT);"));
 }
+
+#[test]
+fn create_table_if_not_exists_doesnt_hit_unreachable() {
+    let mut m = Migration::new();
+    m.create_table_if_not_exists("artist", |t| {
+        t.add_column("name", types::text().nullable(true));
+        t.add_column("description", types::text().nullable(true));
+        t.add_column("pic", types::text().nullable(true));
+        t.add_column("mbid", types::text().nullable(true));
+    });
+    assert_eq!(m.make::<MySql>(), String::from("CREATE TABLE artist IF NOT EXISTS (id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, name TEXT, description TEXT, pic TEXT, mbid TEXT);"));
+}

--- a/src/tests/pg/create_table.rs
+++ b/src/tests/pg/create_table.rs
@@ -15,6 +15,18 @@ fn simple_table() {
 }
 
 #[test]
+fn create_table_if_not_exists_doesnt_hit_unreachable() {
+    let mut m = Migration::new();
+    m.create_table_if_not_exists("artist", |t| {
+        t.add_column("name", types::text().nullable(true));
+        t.add_column("description", types::text().nullable(true));
+        t.add_column("pic", types::text().nullable(true));
+        t.add_column("mbid", types::text().nullable(true));
+    });
+    assert_eq!(m.make::<Pg>(), String::from("CREATE TABLE \"artist\" IF NOT EXISTS (\"id\" SERIAL PRIMARY KEY NOT NULL, \"name\" TEXT, \"description\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);"));
+}
+
+#[test]
 fn basic_fields() {
     let mut m = Migration::new();
     m.create_table("users", |t: &mut Table| {

--- a/src/tests/sqlite3/create_table.rs
+++ b/src/tests/sqlite3/create_table.rs
@@ -20,3 +20,16 @@ fn create_multiple_tables() {
     });
     assert_eq!(m.make::<Sqlite>(), String::from("CREATE TABLE \"artist\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"name\" TEXT, \"description\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);CREATE TABLE \"album\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"name\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);"));
 }
+
+
+#[test]
+fn create_table_if_not_exists_doesnt_hit_unreachable() {
+    let mut m = Migration::new();
+    m.create_table_if_not_exists("artist", |t| {
+        t.add_column("name", types::text().nullable(true));
+        t.add_column("description", types::text().nullable(true));
+        t.add_column("pic", types::text().nullable(true));
+        t.add_column("mbid", types::text().nullable(true));
+    });
+    assert_eq!(m.make::<Sqlite>(), String::from("CREATE TABLE IF NOT EXISTS \"artist\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"name\" TEXT, \"description\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);"));
+}


### PR DESCRIPTION
I updated the match arm to match the name same name of the function that was added to the changes vector.  Here's the code I was using to test.  This should resolve #45 

```
use barrel::backend::Pg;
use barrel::types;
use barrel::*;


#[derive(Clone, Debug)]
pub struct ColumnDef{
    pub name: String,
    pub data_type: String,
}

fn main() {

    let mut m = Migration::new();
    m.create_table_if_not_exists("my_table", move |t| {
      let columns: Vec<ColumnDef> = vec![ ColumnDef { name: String::from("col1"), data_type: String::from("varchar(32)") } ];
      for col in columns {
        let cname: &str = &col.name;
        t.add_column(cname, types::varchar(255));
      }
    }).without_id();
}
```

I will be adding a test for this.