### PR TITLE
Renaming `DatabaseExecutor` to `SqlRunner` to sound less Java

### DIFF
--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -1,4 +1,4 @@
-//! A simple module meant for library developers
+//! A module meant for library developers
 //!
 //! `barrel` can be used with different migration toolkits or
 //! SQL adapters. You can either use it to just generate strings
@@ -13,7 +13,7 @@
 /// An object of this trait can be given to a `Migration` object to
 /// automatically generate and run the given SQL string for a
 /// database connection which is wrapped by it
-pub trait DatabaseExecutor {
+pub trait SqlRunner {
     /// Execute the migration on a backend
     fn execute<S: Into<String>>(&mut self, sql: S);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,12 +62,12 @@
 //! Running a migration with `barrel` is then super easy.
 //!
 //! ```rust
-//! use barrel::connectors::DatabaseExecutor;
+//! use barrel::connectors::SqlRunner;
 //! # use barrel::Migration;
 //! # use barrel::backend::Pg;
 //!
-//! struct MyExecutor;
-//! impl DatabaseExecutor for MyExecutor {
+//! struct MyRunner;
+//! impl SqlRunner for MyRunner {
 //!     fn execute<S: Into<String>>(&mut self, sql: S) {
 //!         # let s: String = sql.into();
 //!         // ...
@@ -75,8 +75,8 @@
 //! }
 //!
 //! # let mut m = Migration::new();
-//! # let mut executor = MyExecutor;
-//! m.execute::<MyExecutor, Pg>(&mut executor);
+//! # let mut executor = MyRunner;
+//! m.execute::<Pg, _>(&mut executor);
 //! ```
 //!
 //! In this case `executor` is your provided type which implements the required

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -16,7 +16,7 @@ use crate::types;
 use crate::DatabaseChange;
 
 use crate::backend::SqlGenerator;
-use crate::connectors::DatabaseExecutor;
+use crate::connectors::SqlRunner;
 
 use std::rc::Rc;
 
@@ -116,7 +116,7 @@ impl Migration {
 
     /// Pass a reference to a migration toolkit runner which will
     /// automatically generate and execute
-    pub fn execute<T: DatabaseExecutor, S: SqlGenerator>(&self, runner: &mut T) {
+    pub fn execute<S: SqlGenerator, T: SqlRunner>(&self, runner: &mut T) {
         runner.execute(self.make::<S>());
     }
 


### PR DESCRIPTION
This also includes documentation updates as well
as some minor quality-of-life changes such as the
order of the Generic parameters